### PR TITLE
Fix: main.go:10:2: cannot find package 'github.com/driftsec/parabuste…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+parabuster

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/driftsec/parabuster
+
+go 1.18
+
+require github.com/PuerkitoBio/goquery v1.8.0
+
+require (
+	github.com/andybalholm/cascadia v1.3.1 // indirect
+	golang.org/x/net v0.0.0-20210916014120-12bc252f5db8 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,11 @@
+github.com/PuerkitoBio/goquery v1.8.0 h1:PJTF7AmFCFKk1N6V6jmKfrNH9tV5pNE6lZMkG0gta/U=
+github.com/PuerkitoBio/goquery v1.8.0/go.mod h1:ypIiRMtY7COPGk+I/YbZLbxsxn9g5ejnI2HSMtkjZvI=
+github.com/andybalholm/cascadia v1.3.1 h1:nhxRkql1kdYCc8Snf7D5/D3spOX+dBgjA6u8x004T2c=
+github.com/andybalholm/cascadia v1.3.1/go.mod h1:R4bJ1UQfqADjvDa4P6HZHLh/3OxWWEqc0Sk8XGwHqvA=
+golang.org/x/net v0.0.0-20210916014120-12bc252f5db8 h1:/6y1LfuqNuQdHAm0jjtPtgRcxIxjVZgm5OTu8/QhZvk=
+golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
Fixed: 

```
main.go:10:2: cannot find package "github.com/driftsec/parabuster/attack" in any of:
        /usr/local/go/src/github.com/driftsec/parabuster/attack (from $GOROOT)
        /home/khan/go/src/github.com/driftsec/parabuster/attack (from $GOPATH)
main.go:7:2: cannot find package "github.com/driftsec/parabuster/core" in any of:
        /usr/local/go/src/github.com/driftsec/parabuster/core (from $GOROOT)
        /home/khan/go/src/github.com/driftsec/parabuster/core (from $GOPATH)
main.go:8:2: cannot find package "github.com/driftsec/parabuster/find" in any of:
        /usr/local/go/src/github.com/driftsec/parabuster/find (from $GOROOT)
        /home/khan/go/src/github.com/driftsec/parabuster/find (from $GOPATH)
```